### PR TITLE
Enable more codecs and add a new API `nestegg_read_last_packet()`

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -72,6 +72,12 @@ extern "C" {
 #define NESTEGG_CODEC_VP9     2       /**< Track uses Google On2 VP9 codec. */
 #define NESTEGG_CODEC_OPUS    3       /**< Track uses Xiph Opus codec. */
 #define NESTEGG_CODEC_AV1     4       /**< Track uses AOMedia AV1 codec. */
+#define NESTEGG_CODEC_AVC     5       /**< Track uses H.264/AVC codec. */
+#define NESTEGG_CODEC_HEVC    6       /**< Track uses H.265/HEVC codec. */
+#define NESTEGG_CODEC_AAC     7       /**< Track uses AAC codec. */
+#define NESTEGG_CODEC_FLAC    8       /**< Track uses FLAC codec. */
+#define NESTEGG_CODEC_MP3     9       /**< Track uses MP3 codec */
+#define NESTEGG_CODEC_PCM     10      /**< Track uses PCM codec. */
 #define NESTEGG_CODEC_UNKNOWN INT_MAX /**< Track uses unknown codec. */
 
 #define NESTEGG_VIDEO_MONO              0 /**< Track is mono video. */

--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -377,6 +377,17 @@ int nestegg_read_reset(nestegg * context);
     @retval -1 Error. */
 int nestegg_read_packet(nestegg * context, nestegg_packet ** packet);
 
+/** Read the last-ending packet for a track without affecting current parser
+    state.
+    @param context  Stream context initialized by #nestegg_init.
+    @param track    Zero based track number.
+    @param packet  Storage for the returned nestegg_packet.
+    @retval 0       Success.
+    @retval -1      Error. */
+int nestegg_read_last_packet(nestegg * context,
+                             unsigned int track,
+                             nestegg_packet ** packet);
+
 /** Destroy a nestegg_packet and free associated memory.
     @param packet #nestegg_packet to be freed. @see nestegg_read_packet */
 void nestegg_free_packet(nestegg_packet * packet);

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -3153,6 +3153,76 @@ nestegg_read_packet(nestegg * ctx, nestegg_packet ** pkt)
   return 1;
 }
 
+int
+nestegg_read_last_packet(nestegg * context, unsigned int track,
+                         nestegg_packet ** packet)
+{
+  if (!context || !packet) {
+    return -1;
+  }
+
+  *packet = NULL;
+
+  // Save and restore the parser state later.
+  struct saved_state saved;
+  ne_ctx_save(context, &saved);
+
+  uint64_t max_end_ns = 0;
+  nestegg_packet * last_packet = NULL;
+
+  for (;;) {
+    nestegg_packet * pkt = NULL;
+    int r = nestegg_read_packet(context, &pkt);
+    if (r == 0) {
+      /* EOS */
+      break;
+    }
+    if (r < 0) {
+      if (pkt) {
+        nestegg_free_packet(pkt);
+      }
+      if (last_packet) {
+        nestegg_free_packet(last_packet);
+        last_packet = NULL;
+      }
+      ne_ctx_restore(context, &saved);
+      return -1;
+    }
+
+    unsigned int pkt_track = 0;
+    if (nestegg_packet_track(pkt, &pkt_track) == 0 && pkt_track == track) {
+      // Calculate the end timestamp of this packet.
+      uint64_t ts = 0;
+      uint64_t dur = 0;
+      nestegg_packet_tstamp(pkt, &ts);
+      if (nestegg_packet_duration(pkt, &dur) != 0) {
+        dur = 0;
+      }
+      uint64_t end_ns = ts + dur;
+      if (end_ns >= max_end_ns) {
+        if (last_packet) {
+          nestegg_free_packet(last_packet);
+        }
+        last_packet = pkt;
+        max_end_ns = end_ns;
+        pkt = NULL;
+      }
+    }
+
+    if (pkt) {
+      nestegg_free_packet(pkt);
+    }
+  }
+
+  ne_ctx_restore(context, &saved);
+
+  if (!last_packet) {
+    return -1;
+  }
+  *packet = last_packet;
+  return 0;
+}
+
 void
 nestegg_free_packet(nestegg_packet * pkt)
 {

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -177,6 +177,19 @@ enum ebml_type_enum {
 #define TRACK_ID_AV1                "V_AV1"
 #define TRACK_ID_VORBIS             "A_VORBIS"
 #define TRACK_ID_OPUS               "A_OPUS"
+#define TRACK_ID_AVC                "V_MPEG4/ISO/AVC"
+#define TRACK_ID_HEVC               "V_MPEGH/ISO/HEVC"
+#define TRACK_ID_AAC                "A_AAC"
+#define TRACK_ID_AAC_MP4_LC         "A_AAC/MPEG4/LC"
+#define TRACK_ID_AAC_MP4_LC_SBR     "A_AAC/MPEG4/LC/SBR"
+#define TRACK_ID_AAC_MP4_LTP        "A_AAC/MPEG4/LTP"
+#define TRACK_ID_AAC_MP4_MAIN       "A_AAC/MPEG4/MAIN"
+#define TRACK_ID_AAC_MP4_SSR        "A_AAC/MPEG4/SSR"
+#define TRACK_ID_FLAC               "A_FLAC"
+#define TRACK_ID_MP3                "A_MPEG/L3"
+#define TRACK_ID_PCM_FLOAT          "A_PCM/FLOAT/IEEE"
+#define TRACK_ID_PCM_INT_BE         "A_PCM/INT/BIG"
+#define TRACK_ID_PCM_INT_LE         "A_PCM/INT/LIT"
 
 /* Track Encryption */
 #define CONTENT_ENC_ALGO_AES        5
@@ -2470,6 +2483,7 @@ nestegg_track_codec_id(nestegg * ctx, unsigned int track)
   if (ne_get_string(entry->codec_id, &codec_id) != 0)
     return -1;
 
+  ctx->log(ctx, NESTEGG_LOG_DEBUG, "nestegg_track_codec_id: %s\n", codec_id);
   if (strcmp(codec_id, TRACK_ID_VP8) == 0)
     return NESTEGG_CODEC_VP8;
 
@@ -2484,6 +2498,31 @@ nestegg_track_codec_id(nestegg * ctx, unsigned int track)
 
   if (strcmp(codec_id, TRACK_ID_OPUS) == 0)
     return NESTEGG_CODEC_OPUS;
+
+  if (strcmp(codec_id, TRACK_ID_AVC) == 0)
+    return NESTEGG_CODEC_AVC;
+
+  if (strcmp(codec_id, TRACK_ID_HEVC) == 0)
+    return NESTEGG_CODEC_HEVC;
+
+  if (strcmp(codec_id, TRACK_ID_AAC) == 0 ||
+      strcmp(codec_id, TRACK_ID_AAC_MP4_LC) == 0 ||
+      strcmp(codec_id, TRACK_ID_AAC_MP4_LC_SBR) == 0 ||
+      strcmp(codec_id, TRACK_ID_AAC_MP4_LTP) == 0 ||
+      strcmp(codec_id, TRACK_ID_AAC_MP4_MAIN) == 0 ||
+      strcmp(codec_id, TRACK_ID_AAC_MP4_SSR) == 0)
+    return NESTEGG_CODEC_AAC;
+
+  if (strcmp(codec_id, TRACK_ID_FLAC) == 0)
+    return NESTEGG_CODEC_FLAC;
+
+  if (strcmp(codec_id, TRACK_ID_MP3) == 0)
+    return NESTEGG_CODEC_MP3;
+
+  if (strcmp(codec_id, TRACK_ID_PCM_FLOAT) == 0 ||
+      strcmp(codec_id, TRACK_ID_PCM_INT_BE) == 0 ||
+      strcmp(codec_id, TRACK_ID_PCM_INT_LE) == 0)
+    return NESTEGG_CODEC_PCM;
 
   return NESTEGG_CODEC_UNKNOWN;
 }
@@ -2505,11 +2544,23 @@ nestegg_track_codec_data_count(nestegg * ctx, unsigned int track,
 
   codec_id = nestegg_track_codec_id(ctx, track);
 
-  if (codec_id == NESTEGG_CODEC_OPUS) {
+  // Usually don't have codec private
+  if (codec_id == NESTEGG_CODEC_MP3 || codec_id == NESTEGG_CODEC_VP8 ||
+      codec_id == NESTEGG_CODEC_VP9) {
+    *count = 0;
+    return 0;
+  }
+
+  // Usually one codec private
+  if (codec_id == NESTEGG_CODEC_OPUS || codec_id == NESTEGG_CODEC_PCM ||
+      codec_id == NESTEGG_CODEC_AAC  || codec_id == NESTEGG_CODEC_FLAC ||
+      codec_id == NESTEGG_CODEC_AVC || codec_id == NESTEGG_CODEC_HEVC ||
+      codec_id == NESTEGG_CODEC_AV1) {
     *count = 1;
     return 0;
   }
 
+  // Vorbis spec requires three headers in the codec private
   if (codec_id != NESTEGG_CODEC_VORBIS)
     return -1;
 
@@ -2542,8 +2593,8 @@ nestegg_track_codec_data(nestegg * ctx, unsigned int track, unsigned int item,
   if (!entry)
     return -1;
 
-  if (nestegg_track_codec_id(ctx, track) != NESTEGG_CODEC_VORBIS &&
-      nestegg_track_codec_id(ctx, track) != NESTEGG_CODEC_OPUS)
+  unsigned int count = 0;
+  if (nestegg_track_codec_data_count(ctx, track, &count) != 0 || count == 0)
     return -1;
 
   if (ne_get_binary(entry->codec_private, &codec_private) != 0)


### PR DESCRIPTION
@kinetiknz Could you help me review whether my draft is on the right track? It adds support for more codecs that may be available in Gecko, and introduces a new method which will be used to calculate the total frame count for AAC. Thanks!