### PR TITLE
Add `nestegg_read_total_frames_count` to read the total number of frames from Block Lacing.

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -387,6 +387,13 @@ int nestegg_read_last_packet(nestegg * context,
                              unsigned int track,
                              nestegg_packet ** packet);
 
+/** Read total frames count for a track without affecting current parser state.
+    @param context    Stream context initialized by #nestegg_init.
+    @param framesOut  Storage for the returned total frames count.
+    @retval 0         Success.
+    @retval -1        Error. */
+int nestegg_read_total_frames_count(nestegg * context, uint64_t* framesOut);
+
 /** Destroy a nestegg_packet and free associated memory.
     @param packet #nestegg_packet to be freed. @see nestegg_read_packet */
 void nestegg_free_packet(nestegg_packet * packet);


### PR DESCRIPTION
Per Matroska Block Lacing [1], the number of frames in a Block can be determined by its Lacing value. This new function allows Gecko to accurately determine the total media frames in an MKV file.

[1] https://www.matroska.org/technical/notes.html