### PR TITLE
Improve handling of large track counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ test-driver
 test-suite.log
 test/dump
 test/dump.exe
+test/indexing
+test/indexing.exe
 test/regress
 test/regress.exe
 test/*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ src_libnestegg_la_SOURCES = \
 
 src_libnestegg_la_LDFLAGS = -export-symbols-regex '^nestegg_' -no-undefined
 
-check_PROGRAMS = test/dump test/regress
+check_PROGRAMS = test/dump test/regress test/indexing
 
 test_dump_SOURCES = test/dump.c
 test_dump_LDADD = src/libnestegg.la
@@ -33,7 +33,10 @@ test_dump_LDADD = src/libnestegg.la
 test_regress_SOURCES = test/regress.c
 test_regress_LDADD = src/libnestegg.la
 
-TESTS = test/regress.test
+test_indexing_SOURCES = test/indexing.c
+test_indexing_LDADD = src/libnestegg.la
+
+TESTS = test/regress.test test/indexing
 
 dist-hook:
 	find $(distdir) -type d -name '.git' | xargs rm -rf

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -164,6 +164,7 @@ enum ebml_type_enum {
 #define LIMIT_BINARY                (1 << 24)
 #define LIMIT_BLOCK                 (1 << 30)
 #define LIMIT_FRAME                 (1 << 28)
+#define LIMIT_TRACKS                1000U
 #define IO_BUFFER_SIZE              8192
 
 /* Field Flags */
@@ -242,6 +243,7 @@ struct ebml_list_node {
 struct ebml_list {
   struct ebml_list_node * head;
   struct ebml_list_node * tail;
+  size_t count;
 };
 
 struct ebml_type {
@@ -378,6 +380,11 @@ struct tracks {
   struct ebml_list track_entry;
 };
 
+struct track_number_index {
+  uint64_t number;
+  unsigned int index;
+};
+
 struct cue_track_positions {
   struct ebml_type track;
   struct ebml_type cluster_position;
@@ -467,6 +474,8 @@ struct nestegg {
   struct ebml ebml;
   struct segment segment;
   int64_t segment_offset;
+  struct track_entry ** track_by_index;
+  struct track_number_index * track_by_number;
   unsigned int track_count;
   /* Last read cluster. */
   uint64_t cluster_timecode;
@@ -1329,6 +1338,12 @@ ne_read_master(nestegg * ctx, struct ebml_element_desc * desc)
 
   list = (struct ebml_list *) (ctx->ancestor->data + desc->offset);
 
+  if (desc->id == ID_TRACK_ENTRY && list->count >= LIMIT_TRACKS) {
+    ctx->log(ctx, NESTEGG_LOG_ERROR,
+             "TrackEntry count exceeds limit of %u", LIMIT_TRACKS);
+    return -1;
+  }
+
   node = ne_pool_alloc(sizeof(*node), ctx->alloc_pool);
   if (!node)
     return -1;
@@ -1343,6 +1358,7 @@ ne_read_master(nestegg * ctx, struct ebml_element_desc * desc)
   list->tail = node;
   if (!list->head)
     list->head = node;
+  list->count += 1;
 
   ctx->log(ctx, NESTEGG_LOG_DEBUG, " -> using data %p", node->data);
 
@@ -1715,31 +1731,98 @@ ne_get_timecode_scale(nestegg * ctx)
 }
 
 static int
+ne_compare_track_number_index(void const * a, void const * b)
+{
+  struct track_number_index const * ta = a;
+  struct track_number_index const * tb = b;
+
+  if (ta->number < tb->number)
+    return -1;
+  if (ta->number > tb->number)
+    return 1;
+  return 0;
+}
+
+static int
+ne_init_track_indexes(nestegg * ctx)
+{
+  struct ebml_list * tracks = &ctx->segment.tracks.track_entry;
+  struct ebml_list_node * node;
+  size_t i;
+
+  if (tracks->count == 0 || tracks->count > LIMIT_TRACKS)
+    return -1;
+
+  ctx->track_by_index =
+    ne_pool_alloc(tracks->count * sizeof(*ctx->track_by_index),
+                  ctx->alloc_pool);
+  if (!ctx->track_by_index)
+    return -1;
+
+  ctx->track_by_number =
+    ne_pool_alloc(tracks->count * sizeof(*ctx->track_by_number),
+                  ctx->alloc_pool);
+  if (!ctx->track_by_number)
+    return -1;
+
+  node = tracks->head;
+  for (i = 0; i < tracks->count; ++i) {
+    struct track_entry * entry;
+    uint64_t number;
+
+    if (!node || node->id != ID_TRACK_ENTRY)
+      return -1;
+
+    entry = node->data;
+    if (ne_get_uint(entry->number, &number) != 0 || number == 0)
+      return -1;
+
+    ctx->track_by_index[i] = entry;
+    ctx->track_by_number[i].number = number;
+    ctx->track_by_number[i].index = (unsigned int) i;
+    node = node->next;
+  }
+
+  if (node)
+    return -1;
+
+  qsort(ctx->track_by_number, tracks->count,
+        sizeof(*ctx->track_by_number), ne_compare_track_number_index);
+
+  for (i = 1; i < tracks->count; ++i) {
+    if (ctx->track_by_number[i - 1].number ==
+        ctx->track_by_number[i].number)
+      return -1;
+  }
+
+  ctx->track_count = (unsigned int) tracks->count;
+  return 0;
+}
+
+static int
 ne_map_track_number_to_index(nestegg * ctx,
-                             unsigned int track_number,
+                             uint64_t track_number,
                              unsigned int * track_index)
 {
-  struct ebml_list_node * node;
-  struct track_entry * t_entry;
-  uint64_t t_number = 0;
-
-  if (!track_index)
-    return -1;
-  *track_index = 0;
+  size_t start = 0;
+  size_t end = ctx->track_count;
 
   if (track_number == 0)
     return -1;
 
-  node = ctx->segment.tracks.track_entry.head;
-  while (node) {
-    assert(node->id == ID_TRACK_ENTRY);
-    t_entry = node->data;
-    if (ne_get_uint(t_entry->number, &t_number) != 0)
-      return -1;
-    if (t_number == track_number)
+  while (start < end) {
+    size_t middle = start + (end - start) / 2;
+    struct track_number_index const * entry = &ctx->track_by_number[middle];
+
+    if (track_number < entry->number) {
+      end = middle;
+    } else if (track_number > entry->number) {
+      start = middle + 1;
+    } else {
+      if (track_index)
+        *track_index = entry->index;
       return 0;
-    *track_index += 1;
-    node = node->next;
+    }
   }
 
   return -1;
@@ -1748,19 +1831,10 @@ ne_map_track_number_to_index(nestegg * ctx,
 static struct track_entry *
 ne_find_track_entry(nestegg * ctx, unsigned int track)
 {
-  struct ebml_list_node * node;
-  unsigned int tracks = 0;
+  if (track >= ctx->track_count)
+    return NULL;
 
-  node = ctx->segment.tracks.track_entry.head;
-  while (node) {
-    assert(node->id == ID_TRACK_ENTRY);
-    if (track == tracks)
-      return node->data;
-    tracks += 1;
-    node = node->next;
-  }
-
-  return NULL;
+  return ctx->track_by_index[track];
 }
 
 static struct frame *
@@ -2515,7 +2589,6 @@ nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback, int64_t ma
 {
   int r;
   uint64_t id, version, docversion;
-  struct ebml_list_node * track;
   char * doctype;
   nestegg * ctx;
 
@@ -2575,12 +2648,9 @@ nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback, int64_t ma
     return -1;
   }
 
-  track = ctx->segment.tracks.track_entry.head;
-  ctx->track_count = 0;
-
-  while (track) {
-    ctx->track_count += 1;
-    track = track->next;
+  if (ne_init_track_indexes(ctx) != 0) {
+    nestegg_destroy(ctx);
+    return -1;
   }
 
   r = ne_ctx_save(ctx, &ctx->saved);

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -2317,11 +2317,11 @@ ne_find_seek_for_id(struct ebml_list_node * seek_head, uint64_t id)
 }
 
 static struct cue_track_positions *
-ne_find_cue_position_for_track(nestegg * ctx, struct ebml_list_node * node, unsigned int track)
+ne_find_cue_position_for_track_number(struct ebml_list_node * node,
+                                      uint64_t wanted_track_number)
 {
   struct cue_track_positions * pos = NULL;
   uint64_t track_number;
-  unsigned int t;
 
   while (node) {
     assert(node->id == ID_CUE_TRACK_POSITIONS);
@@ -2329,10 +2329,7 @@ ne_find_cue_position_for_track(nestegg * ctx, struct ebml_list_node * node, unsi
     if (ne_get_uint(pos->track, &track_number) != 0)
       return NULL;
 
-    if (ne_map_track_number_to_index(ctx, track_number, &t) != 0)
-      return NULL;
-
-    if (t == track)
+    if (track_number == wanted_track_number)
       return pos;
 
     node = node->next;
@@ -2342,7 +2339,9 @@ ne_find_cue_position_for_track(nestegg * ctx, struct ebml_list_node * node, unsi
 }
 
 static struct cue_point *
-ne_find_cue_point_for_tstamp(nestegg * ctx, struct ebml_list_node * cue_point, unsigned int track, uint64_t scale, uint64_t tstamp)
+ne_find_cue_point_for_tstamp(struct ebml_list_node * cue_point,
+                             uint64_t track_number, uint64_t scale,
+                             uint64_t tstamp)
 {
   uint64_t time;
   struct cue_point * c, * prev = NULL;
@@ -2357,7 +2356,8 @@ ne_find_cue_point_for_tstamp(nestegg * ctx, struct ebml_list_node * cue_point, u
     if (ne_get_uint(c->time, &time) == 0 && time * scale > tstamp)
       break;
 
-    if (ne_find_cue_position_for_track(ctx, c->cue_track_positions.head, track) != NULL)
+    if (ne_find_cue_position_for_track_number(c->cue_track_positions.head,
+                                               track_number) != NULL)
       prev = c;
 
     cue_point = cue_point->next;
@@ -2723,7 +2723,6 @@ nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offse
   uint64_t seek_pos, track_number, tc_scale, time;
   struct ebml_list_node * cues_node = ctx->segment.cues.cue_point.head;
   struct ebml_list_node * cue_pos_node = NULL;
-  unsigned int track = 0, track_count = 0, track_index;
 
   if (!start_pos || !end_pos || !tstamp)
     return -1;
@@ -2741,8 +2740,6 @@ nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offse
       return -1;
   }
 
-  nestegg_track_count(ctx, &track_count);
-
   tc_scale = ne_get_timecode_scale(ctx);
   if (tc_scale == 0)
     return -1;
@@ -2754,29 +2751,25 @@ nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offse
     while (cue_pos_node) {
       assert(cue_pos_node->id == ID_CUE_TRACK_POSITIONS);
       pos = cue_pos_node->data;
-      for (track = 0; track < track_count; ++track) {
-        if (ne_get_uint(pos->track, &track_number) != 0)
-          return -1;
+      if (ne_get_uint(pos->track, &track_number) != 0)
+        return -1;
 
-        if (ne_map_track_number_to_index(ctx, track_number, &track_index) != 0)
-          return -1;
+      if (ne_map_track_number_to_index(ctx, track_number, NULL) != 0)
+        return -1;
 
-        if (track_index == track) {
-          if (ne_get_uint(pos->cluster_position, &seek_pos) != 0)
-            return -1;
-          if (cluster_count == cluster_num) {
-            *start_pos = ctx->segment_offset + seek_pos;
-            if (ne_get_uint(cue_point->time, &time) != 0)
-              return -1;
-            *tstamp = time * tc_scale;
-          } else if (cluster_count == cluster_num + 1) {
-            *end_pos = ctx->segment_offset + seek_pos - 1;
-            range_obtained = 1;
-            break;
-          }
-          cluster_count++;
-        }
+      if (ne_get_uint(pos->cluster_position, &seek_pos) != 0)
+        return -1;
+      if (cluster_count == cluster_num) {
+        *start_pos = ctx->segment_offset + seek_pos;
+        if (ne_get_uint(cue_point->time, &time) != 0)
+          return -1;
+        *tstamp = time * tc_scale;
+      } else if (cluster_count == cluster_num + 1) {
+        *end_pos = ctx->segment_offset + seek_pos - 1;
+        range_obtained = 1;
+        break;
       }
+      cluster_count++;
       cue_pos_node = cue_pos_node->next;
     }
     cues_node = cues_node->next;
@@ -2810,7 +2803,12 @@ nestegg_track_seek(nestegg * ctx, unsigned int track, uint64_t tstamp)
   int r;
   struct cue_point * cue_point;
   struct cue_track_positions * pos;
-  uint64_t seek_pos, tc_scale;
+  struct track_entry * entry;
+  uint64_t seek_pos, tc_scale, track_number;
+
+  entry = ne_find_track_entry(ctx, track);
+  if (!entry || ne_get_uint(entry->number, &track_number) != 0)
+    return -1;
 
   /* If there are no cues loaded, check for cues element in the seek head
      and load it. */
@@ -2824,12 +2822,13 @@ nestegg_track_seek(nestegg * ctx, unsigned int track, uint64_t tstamp)
   if (tc_scale == 0)
     return -1;
 
-  cue_point = ne_find_cue_point_for_tstamp(ctx, ctx->segment.cues.cue_point.head,
-                                           track, tc_scale, tstamp);
+  cue_point = ne_find_cue_point_for_tstamp(ctx->segment.cues.cue_point.head,
+                                           track_number, tc_scale, tstamp);
   if (!cue_point)
     return -1;
 
-  pos = ne_find_cue_position_for_track(ctx, cue_point->cue_track_positions.head, track);
+  pos = ne_find_cue_position_for_track_number(
+    cue_point->cue_track_positions.head, track_number);
   if (pos == NULL)
     return -1;
 

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -442,7 +442,6 @@ struct frame {
   unsigned char * data;
   size_t length;
   struct frame_encryption * frame_encryption;
-  struct frame * next;
 };
 
 struct block_additional {
@@ -488,7 +487,8 @@ struct nestegg_packet {
   uint64_t timecode;
   uint64_t duration;
   int read_duration;
-  struct frame * frame;
+  struct frame ** frames;
+  unsigned int frame_count;
   struct block_additional * block_additional;
   int64_t discard_padding;
   int read_discard_padding;
@@ -1848,7 +1848,6 @@ ne_alloc_frame(void)
   f->data = NULL;
   f->length = 0;
   f->frame_encryption = NULL;
-  f->next = NULL;
 
   return f;
 }
@@ -1889,7 +1888,7 @@ ne_read_block(nestegg * ctx, uint64_t block_id, uint64_t block_size, nestegg_pac
   int r;
   int64_t timecode, abs_timecode;
   nestegg_packet * pkt;
-  struct frame * f, * last;
+  struct frame * f;
   struct track_entry * entry;
   uint64_t track_number, length, frame_sizes[256], cluster_tc, flags, frames, tc_scale, total,
            encoding_type, encryption_algo, encryption_mode;
@@ -2030,11 +2029,15 @@ ne_read_block(nestegg * ctx, uint64_t block_id, uint64_t block_size, nestegg_pac
   pkt->track = track;
   pkt->timecode = ne_saturate_mul_uint64((uint64_t) abs_timecode, tc_scale);
   pkt->keyframe = keyframe;
+  pkt->frames = ne_alloc((size_t) frames * sizeof(*pkt->frames));
+  if (!pkt->frames) {
+    nestegg_free_packet(pkt);
+    return -1;
+  }
 
   ctx->log(ctx, NESTEGG_LOG_DEBUG, "%sblock t %lld pts %f f %llx frames: %llu",
            block_id == ID_BLOCK ? "" : "simple", pkt->track, pkt->timecode / 1e9, flags, frames);
 
-  last = NULL;
   for (i = 0; i < frames; ++i) {
     if (frame_sizes[i] > LIMIT_FRAME) {
       nestegg_free_packet(pkt);
@@ -2131,11 +2134,7 @@ ne_read_block(nestegg * ctx, uint64_t block_id, uint64_t block_size, nestegg_pac
       return r;
     }
 
-    if (!last)
-      pkt->frame = f;
-    else
-      last->next = f;
-    last = f;
+    pkt->frames[pkt->frame_count++] = f;
   }
 
   *data = pkt;
@@ -3682,14 +3681,11 @@ nestegg_read_last_packet(nestegg * context, unsigned int track,
 void
 nestegg_free_packet(nestegg_packet * pkt)
 {
-  struct frame * frame;
+  unsigned int i;
 
-  while (pkt->frame) {
-    frame = pkt->frame;
-    pkt->frame = frame->next;
-
-    ne_free_frame(frame);
-  }
+  for (i = 0; i < pkt->frame_count; ++i)
+    ne_free_frame(pkt->frames[i]);
+  free(pkt->frames);
 
   ne_free_block_additions(pkt->block_additional);
 
@@ -3753,15 +3749,7 @@ nestegg_packet_end_offset(nestegg_packet * pkt, int64_t * end_offset)
 int
 nestegg_packet_count(nestegg_packet * pkt, unsigned int * count)
 {
-  struct frame * f = pkt->frame;
-
-  *count = 0;
-
-  while (f) {
-    *count += 1;
-    f = f->next;
-  }
-
+  *count = pkt->frame_count;
   return 0;
 }
 
@@ -3769,23 +3757,18 @@ int
 nestegg_packet_data(nestegg_packet * pkt, unsigned int item,
                     unsigned char ** data, size_t * length)
 {
-  struct frame * f = pkt->frame;
-  unsigned int count = 0;
+  struct frame * f;
 
   *data = NULL;
   *length = 0;
 
-  while (f) {
-    if (count == item) {
-      *data = f->data;
-      *length = f->length;
-      return 0;
-    }
-    count += 1;
-    f = f->next;
-  }
+  if (item >= pkt->frame_count)
+    return -1;
 
-  return -1;
+  f = pkt->frames[item];
+  *data = f->data;
+  *length = f->length;
+  return 0;
 }
 
 int
@@ -3812,7 +3795,7 @@ nestegg_packet_additional_data(nestegg_packet * pkt, unsigned int id,
 int
 nestegg_packet_encryption(nestegg_packet * pkt)
 {
-  struct frame * f = pkt->frame;
+  struct frame * f = pkt->frames[0];
   unsigned char encrypted_bit;
   unsigned char partitioned_bit;
 
@@ -3820,7 +3803,7 @@ nestegg_packet_encryption(nestegg_packet * pkt)
     return NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE;
 
   /* Should never have parsed blocks with both encryption and lacing */
-  assert(f->next == NULL);
+  assert(pkt->frame_count == 1);
 
   encrypted_bit = f->frame_encryption->signal_byte & ENCRYPTED_BIT_MASK;
   partitioned_bit = f->frame_encryption->signal_byte & PARTITIONED_BIT_MASK;
@@ -3837,7 +3820,7 @@ nestegg_packet_encryption(nestegg_packet * pkt)
 int
 nestegg_packet_iv(nestegg_packet * pkt, unsigned char const ** iv, size_t * length)
 {
-  struct frame * f = pkt->frame;
+  struct frame * f = pkt->frames[0];
   unsigned char encrypted_bit;
 
   *iv = NULL;
@@ -3846,7 +3829,7 @@ nestegg_packet_iv(nestegg_packet * pkt, unsigned char const ** iv, size_t * leng
     return -1;
 
   /* Should never have parsed blocks with both encryption and lacing */
-  assert(f->next == NULL);
+  assert(pkt->frame_count == 1);
 
   encrypted_bit = f->frame_encryption->signal_byte & ENCRYPTED_BIT_MASK;
 
@@ -3863,7 +3846,7 @@ nestegg_packet_offsets(nestegg_packet * pkt,
                        uint32_t const ** partition_offsets,
                        uint8_t * num_partitions)
 {
-  struct frame * f = pkt->frame;
+  struct frame * f = pkt->frames[0];
   unsigned char encrypted_bit;
   unsigned char partitioned_bit;
 
@@ -3874,7 +3857,7 @@ nestegg_packet_offsets(nestegg_packet * pkt,
     return -1;
 
   /* Should never have parsed blocks with both encryption and lacing */
-  assert(f->next == NULL);
+  assert(pkt->frame_count == 1);
 
   encrypted_bit = f->frame_encryption->signal_byte & ENCRYPTED_BIT_MASK;
   partitioned_bit = f->frame_encryption->signal_byte & PARTITIONED_BIT_MASK;

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1463,10 +1463,12 @@ ne_parse(nestegg * ctx, struct ebml_element_desc * top_level, int64_t max_offset
 
       if (element->type == TYPE_MASTER) {
         if (element->flags & DESC_FLAG_MULTI) {
-          if (ne_read_master(ctx, element) < 0)
+          r = ne_read_master(ctx, element);
+          if (r < 0)
             break;
         } else {
-          if (ne_read_single_master(ctx, element) < 0)
+          r = ne_read_single_master(ctx, element);
+          if (r < 0)
             break;
         }
         continue;

--- a/test/indexing.c
+++ b/test/indexing.c
@@ -1,0 +1,540 @@
+/*
+ * Copyright © 2026 Mozilla Foundation
+ *
+ * This program is made available under an ISC-style license.  See the
+ * accompanying file LICENSE for details.
+ */
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nestegg/nestegg.h"
+
+#define TEST_TRACK_LIMIT 1000U
+
+#define ID_EBML                 0x1a45dfa3U
+#define ID_EBML_READ_VERSION    0x42f7U
+#define ID_DOCTYPE              0x4282U
+#define ID_DOCTYPE_READ_VERSION 0x4285U
+#define ID_SEGMENT              0x18538067U
+#define ID_TRACKS               0x1654ae6bU
+#define ID_TRACK_ENTRY          0xaeU
+#define ID_TRACK_NUMBER         0xd7U
+#define ID_TRACK_UID            0x73c5U
+#define ID_TRACK_TYPE           0x83U
+#define ID_CODEC_ID             0x86U
+#define ID_CUES                 0x1c53bb6bU
+#define ID_CUE_POINT            0xbbU
+#define ID_CUE_TIME             0xb3U
+#define ID_CUE_TRACK_POSITIONS  0xb7U
+#define ID_CUE_TRACK            0xf7U
+#define ID_CUE_CLUSTER_POSITION 0xf1U
+#define ID_CLUSTER              0x1f43b675U
+#define ID_TIMECODE             0xe7U
+#define ID_SIMPLE_BLOCK         0xa3U
+
+struct buffer {
+  unsigned char * data;
+  size_t length;
+  size_t capacity;
+};
+
+struct buffer_io {
+  unsigned char const * data;
+  size_t length;
+  size_t offset;
+};
+
+static void
+buffer_reserve(struct buffer * buffer, size_t extra)
+{
+  size_t required;
+  size_t capacity;
+  unsigned char * data;
+
+  assert(extra <= (size_t) -1 - buffer->length);
+  required = buffer->length + extra;
+  if (required <= buffer->capacity)
+    return;
+
+  capacity = buffer->capacity ? buffer->capacity : 256;
+  while (capacity < required) {
+    assert(capacity <= (size_t) -1 / 2);
+    capacity *= 2;
+  }
+
+  data = realloc(buffer->data, capacity);
+  assert(data);
+  buffer->data = data;
+  buffer->capacity = capacity;
+}
+
+static void
+buffer_put(struct buffer * buffer, void const * data, size_t length)
+{
+  buffer_reserve(buffer, length);
+  memcpy(buffer->data + buffer->length, data, length);
+  buffer->length += length;
+}
+
+static void
+buffer_put_byte(struct buffer * buffer, unsigned char value)
+{
+  buffer_put(buffer, &value, 1);
+}
+
+static void
+buffer_put_be(struct buffer * buffer, uint64_t value, unsigned int width)
+{
+  unsigned int i;
+
+  for (i = width; i > 0; --i)
+    buffer_put_byte(buffer, (unsigned char) (value >> ((i - 1) * 8)));
+}
+
+static void
+buffer_put_id(struct buffer * buffer, uint32_t id)
+{
+  unsigned int width;
+
+  if (id > 0xffffffU)
+    width = 4;
+  else if (id > 0xffffU)
+    width = 3;
+  else if (id > 0xffU)
+    width = 2;
+  else
+    width = 1;
+
+  buffer_put_be(buffer, id, width);
+}
+
+static void
+buffer_put_size(struct buffer * buffer, size_t size)
+{
+  uint64_t limit;
+  uint64_t encoded;
+  unsigned int width;
+
+  for (width = 1; width <= 8; ++width) {
+    limit = (UINT64_C(1) << (7 * width)) - 1;
+    if (size < limit)
+      break;
+  }
+  assert(width <= 8);
+
+  encoded = (uint64_t) size | (UINT64_C(1) << (7 * width));
+  buffer_put_be(buffer, encoded, width);
+}
+
+static void
+buffer_put_vint(struct buffer * buffer, uint64_t value)
+{
+  uint64_t limit;
+  uint64_t encoded;
+  unsigned int width;
+
+  for (width = 1; width <= 8; ++width) {
+    limit = (UINT64_C(1) << (7 * width)) - 1;
+    if (value < limit)
+      break;
+  }
+  assert(width <= 8);
+
+  encoded = value | (UINT64_C(1) << (7 * width));
+  buffer_put_be(buffer, encoded, width);
+}
+
+static void
+buffer_put_master(struct buffer * buffer, uint32_t id,
+                  struct buffer const * payload)
+{
+  buffer_put_id(buffer, id);
+  buffer_put_size(buffer, payload->length);
+  buffer_put(buffer, payload->data, payload->length);
+}
+
+static void
+buffer_put_uint(struct buffer * buffer, uint32_t id, uint64_t value)
+{
+  unsigned int width = 1;
+
+  while (width < 8 && value >= (UINT64_C(1) << (width * 8)))
+    width += 1;
+
+  buffer_put_id(buffer, id);
+  buffer_put_size(buffer, width);
+  buffer_put_be(buffer, value, width);
+}
+
+static void
+buffer_put_string(struct buffer * buffer, uint32_t id, char const * value)
+{
+  size_t length = strlen(value);
+
+  buffer_put_id(buffer, id);
+  buffer_put_size(buffer, length);
+  buffer_put(buffer, value, length);
+}
+
+static void
+buffer_clear(struct buffer * buffer)
+{
+  buffer->length = 0;
+}
+
+static void
+buffer_destroy(struct buffer * buffer)
+{
+  free(buffer->data);
+  memset(buffer, 0, sizeof(*buffer));
+}
+
+static void
+put_ebml_header(struct buffer * file)
+{
+  struct buffer payload = { 0 };
+
+  buffer_put_uint(&payload, ID_EBML_READ_VERSION, 1);
+  buffer_put_string(&payload, ID_DOCTYPE, "webm");
+  buffer_put_uint(&payload, ID_DOCTYPE_READ_VERSION, 2);
+  buffer_put_master(file, ID_EBML, &payload);
+  buffer_destroy(&payload);
+}
+
+static void
+put_track_entry(struct buffer * tracks, uint64_t number)
+{
+  struct buffer entry = { 0 };
+
+  buffer_put_uint(&entry, ID_TRACK_NUMBER, number);
+  buffer_put_uint(&entry, ID_TRACK_UID, number);
+  buffer_put_uint(&entry, ID_TRACK_TYPE, 1);
+  buffer_put_string(&entry, ID_CODEC_ID, "V_VP8");
+  buffer_put_master(tracks, ID_TRACK_ENTRY, &entry);
+  buffer_destroy(&entry);
+}
+
+static void
+put_tracks(struct buffer * element, uint64_t const * numbers,
+           unsigned int count)
+{
+  struct buffer payload = { 0 };
+  unsigned int i;
+
+  for (i = 0; i < count; ++i)
+    put_track_entry(&payload, numbers ? numbers[i] : i + 1);
+
+  buffer_put_master(element, ID_TRACKS, &payload);
+  buffer_destroy(&payload);
+}
+
+static void
+put_cues(struct buffer * element, uint64_t const * numbers,
+         unsigned int count, uint64_t cluster_position)
+{
+  struct buffer cues = { 0 };
+  struct buffer point = { 0 };
+  unsigned int i;
+
+  buffer_put_uint(&point, ID_CUE_TIME, 0);
+  for (i = 0; i < count; ++i) {
+    struct buffer position = { 0 };
+
+    buffer_put_uint(&position, ID_CUE_TRACK, numbers[i]);
+    buffer_put_uint(&position, ID_CUE_CLUSTER_POSITION, cluster_position);
+    buffer_put_master(&point, ID_CUE_TRACK_POSITIONS, &position);
+    buffer_destroy(&position);
+  }
+
+  buffer_put_master(&cues, ID_CUE_POINT, &point);
+  buffer_put_master(element, ID_CUES, &cues);
+  buffer_destroy(&point);
+  buffer_destroy(&cues);
+}
+
+static void
+put_simple_block(struct buffer * cluster, uint64_t track_number,
+                 unsigned char flags, unsigned int frames)
+{
+  struct buffer block = { 0 };
+  unsigned int i;
+
+  assert(frames >= 1 && frames <= 256);
+  buffer_put_vint(&block, track_number);
+  buffer_put_byte(&block, 0);
+  buffer_put_byte(&block, 0);
+  buffer_put_byte(&block, flags);
+
+  if (frames > 1)
+    buffer_put_byte(&block, (unsigned char) (frames - 1));
+
+  for (i = 0; i < frames; ++i)
+    buffer_put_byte(&block, (unsigned char) i);
+
+  buffer_put_master(cluster, ID_SIMPLE_BLOCK, &block);
+  buffer_destroy(&block);
+}
+
+static void
+put_test_cluster(struct buffer * element, uint64_t large_track_number)
+{
+  struct buffer cluster = { 0 };
+
+  buffer_put_uint(&cluster, ID_TIMECODE, 0);
+  put_simple_block(&cluster, large_track_number, 0x80, 1);
+  put_simple_block(&cluster, 1, 0x84, 256);
+  buffer_put_master(element, ID_CLUSTER, &cluster);
+  buffer_destroy(&cluster);
+}
+
+static void
+build_track_file(struct buffer * file, uint64_t const * numbers,
+                 unsigned int count)
+{
+  struct buffer segment = { 0 };
+  struct buffer tracks = { 0 };
+  struct buffer cluster = { 0 };
+  struct buffer cluster_payload = { 0 };
+
+  put_tracks(&tracks, numbers, count);
+  buffer_put_master(&cluster, ID_CLUSTER, &cluster_payload);
+
+  buffer_put(&segment, tracks.data, tracks.length);
+  buffer_put(&segment, cluster.data, cluster.length);
+
+  put_ebml_header(file);
+  buffer_put_master(file, ID_SEGMENT, &segment);
+
+  buffer_destroy(&cluster);
+  buffer_destroy(&cluster_payload);
+  buffer_destroy(&tracks);
+  buffer_destroy(&segment);
+}
+
+static void
+build_indexed_file(struct buffer * file, uint64_t const * numbers,
+                   unsigned int count)
+{
+  struct buffer tracks = { 0 };
+  struct buffer cues = { 0 };
+  struct buffer cluster = { 0 };
+  struct buffer segment = { 0 };
+  size_t old_position;
+  size_t cluster_position = 0;
+
+  put_tracks(&tracks, numbers, count);
+  put_test_cluster(&cluster, numbers[count - 1]);
+
+  do {
+    old_position = cluster_position;
+    buffer_clear(&cues);
+    put_cues(&cues, numbers, count, cluster_position);
+    cluster_position = tracks.length + cues.length;
+  } while (cluster_position != old_position);
+
+  buffer_put(&segment, tracks.data, tracks.length);
+  buffer_put(&segment, cues.data, cues.length);
+  buffer_put(&segment, cluster.data, cluster.length);
+
+  put_ebml_header(file);
+  buffer_put_master(file, ID_SEGMENT, &segment);
+
+  buffer_destroy(&segment);
+  buffer_destroy(&cluster);
+  buffer_destroy(&cues);
+  buffer_destroy(&tracks);
+}
+
+static int64_t
+memory_read(void * destination, size_t length, void * userdata)
+{
+  struct buffer_io * io = userdata;
+  size_t available = io->length - io->offset;
+
+  if (length > available)
+    length = available;
+  if (length == 0)
+    return 0;
+
+  memcpy(destination, io->data + io->offset, length);
+  io->offset += length;
+  return (int64_t) length;
+}
+
+static int
+memory_seek(int64_t offset, int whence, void * userdata)
+{
+  struct buffer_io * io = userdata;
+  int64_t position;
+
+  if (whence == NESTEGG_SEEK_SET)
+    position = offset;
+  else if (whence == NESTEGG_SEEK_CUR)
+    position = (int64_t) io->offset + offset;
+  else if (whence == NESTEGG_SEEK_END)
+    position = (int64_t) io->length + offset;
+  else
+    return -1;
+
+  if (position < 0 || (uint64_t) position > io->length)
+    return -1;
+
+  io->offset = (size_t) position;
+  return 0;
+}
+
+static int64_t
+memory_tell(void * userdata)
+{
+  struct buffer_io * io = userdata;
+  return (int64_t) io->offset;
+}
+
+static int
+init_from_buffer(nestegg ** context, struct buffer const * file,
+                 struct buffer_io * userdata)
+{
+  nestegg_io io;
+
+  userdata->data = file->data;
+  userdata->length = file->length;
+  userdata->offset = 0;
+
+  memset(&io, 0, sizeof(io));
+  io.read = memory_read;
+  io.seek = memory_seek;
+  io.tell = memory_tell;
+  io.userdata = userdata;
+  return nestegg_init(context, io, NULL, -1);
+}
+
+static void
+test_track_limit(void)
+{
+  struct buffer file = { 0 };
+  struct buffer_io userdata;
+  nestegg * context = NULL;
+  unsigned int tracks;
+  unsigned int i;
+  int r;
+
+  build_track_file(&file, NULL, TEST_TRACK_LIMIT);
+  r = init_from_buffer(&context, &file, &userdata);
+  assert(r == 0);
+  assert(nestegg_track_count(context, &tracks) == 0);
+  assert(tracks == TEST_TRACK_LIMIT);
+  for (i = 0; i < tracks; ++i) {
+    assert(nestegg_track_type(context, i) == NESTEGG_TRACK_VIDEO);
+    assert(nestegg_track_codec_id(context, i) == NESTEGG_CODEC_VP8);
+  }
+  assert(nestegg_track_type(context, tracks) == -1);
+  nestegg_destroy(context);
+  buffer_destroy(&file);
+
+  context = NULL;
+  build_track_file(&file, NULL, TEST_TRACK_LIMIT + 1);
+  r = init_from_buffer(&context, &file, &userdata);
+  assert(r == -1);
+  assert(context == NULL);
+  buffer_destroy(&file);
+}
+
+static void
+test_invalid_track_numbers(void)
+{
+  uint64_t duplicate_numbers[] = { 1, 1 };
+  uint64_t zero_number[] = { 0 };
+  struct buffer file = { 0 };
+  struct buffer_io userdata;
+  nestegg * context = NULL;
+
+  build_track_file(&file, duplicate_numbers, 2);
+  assert(init_from_buffer(&context, &file, &userdata) == -1);
+  assert(context == NULL);
+  buffer_destroy(&file);
+
+  build_track_file(&file, zero_number, 1);
+  assert(init_from_buffer(&context, &file, &userdata) == -1);
+  assert(context == NULL);
+  buffer_destroy(&file);
+}
+
+static void
+test_indexed_access(void)
+{
+  uint64_t numbers[] = { 1, 17, UINT64_C(0x100000001) };
+  struct buffer file = { 0 };
+  struct buffer_io userdata;
+  nestegg * context = NULL;
+  nestegg_packet * packet = NULL;
+  unsigned char * data;
+  size_t length;
+  unsigned int count;
+  unsigned int track;
+  unsigned int i;
+  int64_t start;
+  int64_t end;
+  uint64_t timestamp;
+
+  build_indexed_file(&file, numbers, 3);
+  assert(init_from_buffer(&context, &file, &userdata) == 0);
+
+  assert(nestegg_track_count(context, &count) == 0);
+  assert(count == 3);
+  for (i = 0; i < count; ++i) {
+    assert(nestegg_track_type(context, i) == NESTEGG_TRACK_VIDEO);
+    assert(nestegg_track_codec_id(context, i) == NESTEGG_CODEC_VP8);
+  }
+  assert(nestegg_track_codec_id(context, count) == -1);
+
+  assert(nestegg_get_cue_point(context, 0, -1, &start, &end,
+                               &timestamp) == 0);
+  assert(start >= 0);
+  assert(timestamp == 0);
+
+  assert(nestegg_read_packet(context, &packet) == 1);
+  assert(nestegg_packet_track(packet, &track) == 0);
+  assert(track == 2);
+  assert(nestegg_packet_count(packet, &count) == 0);
+  assert(count == 1);
+  assert(nestegg_packet_data(packet, 0, &data, &length) == 0);
+  assert(length == 1 && data[0] == 0);
+  nestegg_free_packet(packet);
+
+  packet = NULL;
+  assert(nestegg_read_packet(context, &packet) == 1);
+  assert(nestegg_packet_track(packet, &track) == 0);
+  assert(track == 0);
+  assert(nestegg_packet_count(packet, &count) == 0);
+  assert(count == 256);
+  for (i = 0; i < count; ++i) {
+    assert(nestegg_packet_data(packet, i, &data, &length) == 0);
+    assert(length == 1 && data[0] == (unsigned char) i);
+  }
+  data = (unsigned char *) 1;
+  length = 1;
+  assert(nestegg_packet_data(packet, count, &data, &length) == -1);
+  assert(data == NULL && length == 0);
+  nestegg_free_packet(packet);
+
+  assert(nestegg_track_seek(context, 2, 0) == 0);
+  packet = NULL;
+  assert(nestegg_read_packet(context, &packet) == 1);
+  assert(nestegg_packet_track(packet, &track) == 0);
+  assert(track == 2);
+  nestegg_free_packet(packet);
+
+  nestegg_destroy(context);
+  buffer_destroy(&file);
+}
+
+int
+main(void)
+{
+  test_track_limit();
+  test_invalid_track_numbers();
+  test_indexed_access();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fix quadratic track metadata lookups by building indexed TrackEntry tables during initialization and limiting files to 1,000 tracks (matching an existing ffmpeg limit). Also optimizes TrackNumber mapping, cue traversal, and laced-frame access, with regression coverage for limits and indexed access.